### PR TITLE
fix: replace __vfs_read with kernel_read

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1988,7 +1988,7 @@ static int readFile(struct file *fp, char *buf, int len)
 
 	while (sum < len) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
-		rlen = __vfs_read(fp, buf + sum, len - sum, &fp->f_pos);
+		rlen = kernel_read(fp, buf + sum, len - sum, &fp->f_pos);
 #else
 		rlen = fp->f_op->read(fp, buf + sum, len - sum, &fp->f_pos);
 #endif


### PR DESCRIPTION
This driver was having problems when loading on my system, complaining
about an unknown symbol __vfs_read. I replaced this function call with
kernel_read.

The driver now loads successfully on my system.

Kernel version: 4.14.21-1-MANJARO

I don't know if that function is available on all kernels >= 4.1 please advise if it isn't!